### PR TITLE
added chrome favicon api for faster retrival of favicon from browser.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@
 </p>
 
 ---
+### 🎹 Keyboard Shortcuts
+
+#### 🌐 On Any Website
+- `Ctrl + Shift + K` → Launch **Spotlight** on websites
+
+#### 🆕 On New Tab Page
+- `Ctrl + /` → Launch **Spotlight** on new tab
+
 
 ## ✨ Features
 
@@ -70,6 +78,7 @@ This will generate a `dist/` folder containing the extension files.
 
 ## 🤝 Contributing
 Contributions are always welcome!
+- If you find any bug/issue or what to add feature please create a issue on it.
 
 To contribute:
 - Fork the repository

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Spotlight",
   "version": "1.0",
   "description": "A beautiful spotlight command palette for your browser.",
-  "permissions": ["history", "tabs", "storage"],
+  "permissions": ["history", "tabs", "storage", "favicon"],
   "chrome_url_overrides": {
     "newtab": "index.html"
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,7 +55,7 @@ export function showSpotlight() {
       } else {
         populateHistory();
       }
-    }, 800);
+    }, 10);
   });
 
   document.addEventListener("keydown", handleGlobalKeys);

--- a/src/ui/favicon.ts
+++ b/src/ui/favicon.ts
@@ -1,0 +1,6 @@
+export function createFaviconURL(url: string) {
+  const favicon = new URL(chrome.runtime.getURL("/_favicon/"));
+  favicon.searchParams.set("pageUrl", url);
+  favicon.searchParams.set("size", "32");
+  return favicon.toString();
+}

--- a/src/ui/list.ts
+++ b/src/ui/list.ts
@@ -1,5 +1,6 @@
 import { InitiatePageNavigation } from "../browser/search";
 import { config } from "../config";
+import { createFaviconURL } from "./favicon";
 
 export function createListItem(title: string, url: string) {
   const li = document.createElement("li");
@@ -18,9 +19,13 @@ export function createListItem(title: string, url: string) {
     /* invalid URL */
   }
 
-  favicon.src = `https://favicon.is/${hostname}`;
+  favicon.src = createFaviconURL(url);
   favicon.onerror = () => {
-    favicon.src = chrome.runtime.getURL("src/assets/icon16.png");
+    favicon.src = `https://favicon.is/${hostname}`;
+    favicon.onerror = () => {
+      favicon.src = chrome.runtime.getURL("src/assets/icon16.png");
+      favicon.onerror = null;
+    };
     favicon.onerror = null;
   };
 


### PR DESCRIPTION
- Added chrome favicon api for faster retrival of favicons directly form the browser cache.
- It will decrease the network requests made to `favicon.is` for displaying favicon.
- it only work on `newtab` and for websites `favicon.is` api is added as a fallback.